### PR TITLE
Remove default channel from the code

### DIFF
--- a/slack-notify.js
+++ b/slack-notify.js
@@ -65,7 +65,6 @@ module.exports = function (url) {
 
     // Merge options with defaults
     var defaults = {
-      channel: '#general',
       username: 'Robot',
       text: '',
       icon_emoji: ':bell:'

--- a/test/api.spec.coffee
+++ b/test/api.spec.coffee
@@ -19,7 +19,6 @@ describe 'API', ->
   it 'slack.send', ->
     slack.send('Hello!')
     expect(slack.request).toHaveBeenCalledWith
-      channel: '#general'
       username: 'Robot'
       text: 'Hello!'
       icon_emoji: ':bell:'
@@ -104,7 +103,6 @@ describe 'API', ->
       icon_url: 'http://something.com/icon.png'
 
     expect(slack.request).toHaveBeenCalledWith
-      channel: '#general'
       username: 'Robot'
       text: 'Hello!'
       icon_url: 'http://something.com/icon.png'
@@ -128,7 +126,6 @@ describe 'API', ->
     , undefined
 
     expect(slack.request).toHaveBeenCalledWith
-      channel: '#general'
       username: 'Robot'
       text: 'Hello!'
       icon_emoji: ':bell:'


### PR DESCRIPTION
Remove default channel name from code to rely on the value from slack web interface.