### PR TITLE
lodash dependancy updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "node": ">=0.10.x"
   },
   "dependencies": {
-    "lodash": "2.4.1",
-    "request": "2.51.0"
+    "lodash": "^3.0.1",
+    "request": "^2.51.0"
   },
   "devDependencies": {
     "jasmine-node": "1.14.5"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">=0.10.x"
   },
   "dependencies": {
-    "lodash": "^3.0.1",
+    "lodash": "^3.10.1",
     "request": "^2.51.0"
   },
   "devDependencies": {


### PR DESCRIPTION
currently npm install throws warnings about lodash being outdated. since the current lodash version is compatible with how its being used, we can safely update.